### PR TITLE
Use CI/CD in the lifecycle of the template itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ In the AWS Console, see if you can find the resources from `setup.tf` (Route 53 
 
 ### Enable GitHub Actions on your repo
 
+* Send a Slack message to #devops-tooling, requesting that GitHub Secrets be added to your repo. Include:
+  * The name of your GitHub repo
+  * The name of your AWS accounts
 * In GitHub, go to the `Actions` tab for your repo (e.g. https://github.com/byu-oit/my-repo/actions)
 * Click the `Enable Actions on this repo` button
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ cd my-new-repo
 git checkout -b dev
 ```
 * Find and replace across the repo:
-  * replace `<account_number>` with your AWS account number, using your `dev` account in `/terraform-iac/dev` and your `prd` account in `/terraform-iac/prd`
+  * replace `977306314792` with your dev AWS account number
+  * replace `539738229445` with your prd AWS account number
   * replace `hw-static-site` with the name of your repo
   * replace `byu-oit-terraform-dev` with the name of your `dev` AWS account
+  * replace `byu_oit_terraform_dev` with the name of your `dev` AWS account (with underscores)
   * replace `byu-oit-terraform-prd` with the name of your `prd` AWS account
+  * replace `byu_oit_terraform_prd` with the name of your `prd` AWS account (with underscores)
 * Commit/push your changes
 ```
 git commit -am "update template with repo specific details" 

--- a/terraform-iac/cpy/app/main.tf
+++ b/terraform-iac/cpy/app/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = "0.12.26"
   backend "s3" {
-    bucket         = "terraform-state-storage-<account_number>"
-    dynamodb_table = "terraform-state-lock-<account_number>"
+    bucket         = "terraform-state-storage-539738229445"
+    dynamodb_table = "terraform-state-lock-539738229445"
     key            = "hw-static-site-cpy/app.tfstate"
     region         = "us-west-2"
   }

--- a/terraform-iac/cpy/setup/setup.tf
+++ b/terraform-iac/cpy/setup/setup.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    bucket         = "terraform-state-storage-<account_number>"
-    dynamodb_table = "terraform-state-lock-<account_number>"
+    bucket         = "terraform-state-storage-539738229445"
+    dynamodb_table = "terraform-state-lock-539738229445"
     key            = "hw-static-site-cpy/setup.tfstate"
     region         = "us-west-2"
   }

--- a/terraform-iac/dev/app/main.tf
+++ b/terraform-iac/dev/app/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = "0.12.26" # must match value in .github/workflows/*.yml
   backend "s3" {
-    bucket         = "terraform-state-storage-<account_number>"
-    dynamodb_table = "terraform-state-lock-<account_number>"
+    bucket         = "terraform-state-storage-977306314792"
+    dynamodb_table = "terraform-state-lock-977306314792"
     key            = "hw-static-site-dev/app.tfstate"
     region         = "us-west-2"
   }

--- a/terraform-iac/dev/setup/setup.tf
+++ b/terraform-iac/dev/setup/setup.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    bucket         = "terraform-state-storage-<account_number>"
-    dynamodb_table = "terraform-state-lock-<account_number>"
+    bucket         = "terraform-state-storage-977306314792"
+    dynamodb_table = "terraform-state-lock-977306314792"
     key            = "hw-static-site-dev/setup.tfstate"
     region         = "us-west-2"
   }

--- a/terraform-iac/prd/app/main.tf
+++ b/terraform-iac/prd/app/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = "0.12.26"
   backend "s3" {
-    bucket         = "terraform-state-storage-<account_number>"
-    dynamodb_table = "terraform-state-lock-<account_number>"
+    bucket         = "terraform-state-storage-539738229445"
+    dynamodb_table = "terraform-state-lock-539738229445"
     key            = "hw-static-site-prd/app.tfstate"
     region         = "us-west-2"
   }

--- a/terraform-iac/prd/setup/setup.tf
+++ b/terraform-iac/prd/setup/setup.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    bucket         = "terraform-state-storage-<account_number>"
-    dynamodb_table = "terraform-state-lock-<account_number>"
+    bucket         = "terraform-state-storage-539738229445"
+    dynamodb_table = "terraform-state-lock-539738229445"
     key            = "hw-static-site-prd/setup.tfstate"
     region         = "us-west-2"
   }

--- a/terraform-iac/stg/app/main.tf
+++ b/terraform-iac/stg/app/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = "0.12.26" # must match value in .github/workflows/*.yml
   backend "s3" {
-    bucket         = "terraform-state-storage-<account_number>"
-    dynamodb_table = "terraform-state-lock-<account_number>"
+    bucket         = "terraform-state-storage-977306314792"
+    dynamodb_table = "terraform-state-lock-977306314792"
     key            = "hw-static-site-stg/app.tfstate"
     region         = "us-west-2"
   }

--- a/terraform-iac/stg/setup/setup.tf
+++ b/terraform-iac/stg/setup/setup.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    bucket         = "terraform-state-storage-<account_number>"
-    dynamodb_table = "terraform-state-lock-<account_number>"
+    bucket         = "terraform-state-storage-977306314792"
+    dynamodb_table = "terraform-state-lock-977306314792"
     key            = "hw-static-site-stg/setup.tfstate"
     region         = "us-west-2"
   }


### PR DESCRIPTION
By adding the terraform-dev and terraform-prd account numbers into the template, we can make the template "functional". This simplifies development of the template and allows us to exercise the CI/CD workflows. It also allows us to prove that the template works.