### PR TITLE
Change deployment workflow name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: CI/CD Pipeline
+name: Deploy
 
 on:
   push:


### PR DESCRIPTION
Change deployment workflow name so that deployments don't show up when we're looking for CI results at https://github.com/byu-oit/hw-static-site/actions?query=workflow%3ACI.