### PR TITLE
Update dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,5 +38,6 @@ updates:
     target-branch: dev
 
 # For each of these, requesting reviews from yourself makes Dependabot PRs easier to find (https://github.com/pulls/review-requested)
-#    reviewers:
-#      - "YourGitHubUsername"
+    reviewers:
+      - byu-oit/devops-tooling
+      - byu-oit/devx


### PR DESCRIPTION
Update dependabot to use teams instead of users as reviewers for each repo.