### PR TITLE
removed incorrect team reviewers from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,5 @@ updates:
     target-branch: dev
 
 # For each of these, requesting reviews from yourself makes Dependabot PRs easier to find (https://github.com/pulls/review-requested)
-    reviewers:
-      - byu-oit/devops-tooling
-      - byu-oit/devx
+#    reviewers:
+#      - byu-oit/your-github-team


### PR DESCRIPTION
Trying to get rid of the devops-tooling team